### PR TITLE
Improving Rect for creating bounds.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rectutils"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Dmitry Stepanov <d1maxa@yandex.ru>"]
 edition = "2021"
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 #![warn(missing_docs)]
 #![forbid(unsafe_code)]
 
-use nalgebra::{Matrix3, Vector2};
+use nalgebra::{Matrix3, SimdPartialOrd, Vector2};
 use num_traits::{NumAssign, Zero};
 use std::fmt::Debug;
 
@@ -36,6 +36,91 @@ where
     }
 }
 
+/// A version of [Rect] that is optionally None.
+/// This simplifies the process of creating a bounding rect from a series of points,
+/// as it can start as None and then build an initial rect from the first point.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct OptionRect<T>(Option<Rect<T>>);
+
+impl<T> Default for OptionRect<T> {
+    fn default() -> Self {
+        Self(None)
+    }
+}
+
+impl<T> OptionRect<T>
+where
+    T: Number + SimdPartialOrd,
+{
+    /// Clip the rectangle to the given bounds.
+    #[inline]
+    pub fn clip(&mut self, bounds: Rect<T>) {
+        if let Some(rect) = self.0 {
+            *self = rect.clip_by(bounds);
+        }
+    }
+    /// Extends the rectangle so it will contain the given point.
+    #[inline]
+    pub fn push(&mut self, p: Vector2<T>) {
+        if let Some(rect) = &mut self.0 {
+            rect.push(p);
+        } else {
+            self.0 = Some(Rect::new(p.x, p.y, T::zero(), T::zero()));
+        }
+    }
+    /// Extends the rectangle so it will contain the other rectangle.
+    ///
+    /// # Notes
+    ///
+    /// To build a bounding rectangle, initialize an OptionRect to default.
+    ///
+    /// ```
+    /// # use nalgebra::Vector2;
+    /// # use rectutils::Rect;
+    ///
+    /// let vertices = [Vector2::new(1.0, 2.0), Vector2::new(-3.0, 5.0)];
+    ///
+    /// let mut bounding_rect = OptionRect::default();
+    ///
+    /// for &v in &vertices {
+    ///     bounding_rect.push(v);
+    /// }
+    ///
+    /// // So long as vertices is not empty, bounding_rect is guaranteed to be some.
+    /// let bounding_rect = bounding_rect.unwrap();
+    /// ```
+    #[inline]
+    pub fn extend_to_contain(&mut self, other: Rect<T>) {
+        if let Some(rect) = &mut self.0 {
+            rect.extend_to_contain(other);
+        } else {
+            self.0 = Some(other);
+        }
+    }
+}
+
+impl<T> From<Rect<T>> for OptionRect<T> {
+    fn from(source: Rect<T>) -> Self {
+        Self(Some(source))
+    }
+}
+impl<T> From<Option<Rect<T>>> for OptionRect<T> {
+    fn from(source: Option<Rect<T>>) -> Self {
+        Self(source)
+    }
+}
+impl<T> std::ops::Deref for OptionRect<T> {
+    type Target = Option<Rect<T>>;
+    fn deref(&self) -> &Option<Rect<T>> {
+        &self.0
+    }
+}
+impl<T> std::ops::DerefMut for OptionRect<T> {
+    fn deref_mut(&mut self) -> &mut Option<Rect<T>> {
+        &mut self.0
+    }
+}
+
 impl<T> Rect<T>
 where
     T: Number,
@@ -46,6 +131,20 @@ where
         Self {
             position: Vector2::new(x, y),
             size: Vector2::new(w, h),
+        }
+    }
+
+    /// Create a new rectangle from two diagonally opposite corner points.
+    /// In other words, create the smallest rectangle containing both given points.
+    pub fn from_points(p0: Vector2<T>, p1: Vector2<T>) -> Self
+    where
+        T: SimdPartialOrd,
+    {
+        let inf = p0.inf(&p1);
+        let sup = p0.sup(&p1);
+        Self {
+            position: inf,
+            size: sup - inf,
         }
     }
 
@@ -105,47 +204,23 @@ where
     ///
     /// # Notes
     ///
-    /// To build bounding rectangle you should correctly initialize initial rectangle:
-    ///
-    /// ```
-    /// # use nalgebra::Vector2;
-    /// # use rectutils::Rect;
-    ///
-    /// let vertices = [Vector2::new(1.0, 2.0), Vector2::new(-3.0, 5.0)];
-    ///
-    /// // This is important part, it must have "invalid" state to correctly
-    /// // calculate bounding rect. Rect::default will give invalid result!
-    /// let mut bounding_rect = Rect::new(f32::MAX, f32::MAX, 0.0, 0.0);
-    ///
-    /// for &v in &vertices {
-    ///     bounding_rect.push(v);
-    /// }
-    /// ```
+    /// To build bounding rectangle you should use [OptionRect].
     #[inline]
-    pub fn push(&mut self, p: Vector2<T>) {
-        if p.x < self.position.x {
-            self.position.x = p.x;
-        }
-        if p.y < self.position.y {
-            self.position.y = p.y;
-        }
-
-        let right_bottom = self.right_bottom_corner();
-
-        if p.x > right_bottom.x {
-            self.size.x = p.x - self.position.x;
-        }
-        if p.y > right_bottom.y {
-            self.size.y = p.y - self.position.y;
-        }
+    pub fn push(&mut self, p: Vector2<T>)
+    where
+        T: SimdPartialOrd,
+    {
+        let p0 = self.left_top_corner();
+        let p1 = self.right_bottom_corner();
+        *self = Self::from_points(p.inf(&p0), p.sup(&p1));
     }
 
     /// Clips the rectangle by some other rectangle and returns a new rectangle that corresponds to
     /// the intersection of both rectangles. If the rectangles does not intersects, the method
-    /// returns this rectangle.
+    /// returns none.
     #[inline]
-    #[must_use = "this method creates new instance of rect"]
-    pub fn clip_by(&self, other: Rect<T>) -> Rect<T> {
+    #[must_use = "this method creates new instance of OptionRect"]
+    pub fn clip_by(&self, other: Rect<T>) -> OptionRect<T> {
         let mut clipped = *self;
 
         if other.x() + other.w() < self.x()
@@ -153,7 +228,7 @@ where
             || other.y() + other.h() < self.y()
             || other.y() > self.y() + self.h()
         {
-            return clipped;
+            return OptionRect::<T>::default();
         }
 
         if clipped.position.x < other.position.x {
@@ -176,7 +251,7 @@ where
             clipped.size.y -= clipped_right_bottom.y - other_right_bottom.y;
         }
 
-        clipped
+        clipped.into()
     }
 
     /// Checks if the rectangle intersects with some other rectangle.
@@ -235,21 +310,15 @@ where
 
     /// Extends the rectangle so it will contain the other rectangle.
     #[inline]
-    pub fn extend_to_contain(&mut self, other: Rect<T>) {
-        if other.position.x < self.position.x {
-            self.position.x = other.position.x;
-        }
-        if other.position.y < self.position.y {
-            self.position.y = other.position.y;
-        }
-        let self_right_bottom_corner = self.right_bottom_corner();
-        let other_right_bottom_corner = other.right_bottom_corner();
-        if other_right_bottom_corner.x > self_right_bottom_corner.x {
-            self.size.x += other_right_bottom_corner.x - self_right_bottom_corner.x;
-        }
-        if other_right_bottom_corner.y > self_right_bottom_corner.y {
-            self.size.y += other_right_bottom_corner.y - self_right_bottom_corner.y;
-        }
+    pub fn extend_to_contain(&mut self, other: Rect<T>)
+    where
+        T: SimdPartialOrd,
+    {
+        let p0 = self.left_top_corner();
+        let p1 = self.right_bottom_corner();
+        let o0 = other.left_top_corner();
+        let o1 = other.right_bottom_corner();
+        *self = Self::from_points(p0.inf(&o0), p1.sup(&o1));
     }
 
     /// Returns the top left corner of the rectangle.
@@ -330,5 +399,280 @@ where
             position: transformed_min,
             size: transformed_max - transformed_min,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn intersects1() {
+        let rect1 = Rect::new(-1, -2, 4, 6);
+        let rect2 = Rect::new(2, 3, 2, 2);
+        assert!(rect1.intersects(rect2));
+    }
+    #[test]
+    fn intersects2() {
+        let rect1 = Rect::new(0, 0, 4, 6);
+        let rect2 = Rect::new(-1, -2, 2, 3);
+        assert!(rect1.intersects(rect2));
+    }
+    #[test]
+    fn not_intersects1() {
+        let rect1 = Rect::new(-1, -2, 3, 4);
+        let rect2 = Rect::new(3, 3, 2, 2);
+        assert!(!rect1.intersects(rect2));
+    }
+    #[test]
+    fn not_intersects2() {
+        let rect1 = Rect::new(-1, -2, 3, 4);
+        let rect2 = Rect::new(2, 1, 2, 2);
+        assert!(!rect1.intersects(rect2));
+    }
+    #[test]
+    fn from_points1() {
+        let rect = Rect::from_points(Vector2::new(-1, -2), Vector2::new(2, 1));
+        assert_eq!(rect, Rect::new(-1, -2, 3, 3));
+    }
+    #[test]
+    fn from_points2() {
+        let rect = Rect::from_points(Vector2::new(-1, 1), Vector2::new(2, -2));
+        assert_eq!(rect, Rect::new(-1, -2, 3, 3));
+    }
+    #[test]
+    fn rect_extend_to_contain() {
+        let mut rect = Rect::new(0.0, 0.0, 1.0, 1.0);
+
+        rect.extend_to_contain(Rect::new(1.0, 1.0, 1.0, 1.0));
+        assert_eq!(rect, Rect::new(0.0, 0.0, 2.0, 2.0));
+
+        rect.extend_to_contain(Rect::new(-1.0, -1.0, 1.0, 1.0));
+        assert_eq!(rect, Rect::new(-1.0, -1.0, 3.0, 3.0));
+
+        rect.extend_to_contain(Rect::new(10.0, -1.0, 1.0, 15.0));
+        assert_eq!(rect, Rect::new(-1.0, -1.0, 12.0, 15.0));
+    }
+    #[test]
+    fn rect_push2() {
+        let mut rect = Rect::new(0.0, 0.0, 1.0, 1.0);
+
+        rect.push(Vector2::new(1.0, 1.0));
+        assert_eq!(rect, Rect::new(0.0, 0.0, 1.0, 1.0));
+
+        rect.push(Vector2::new(-1.0, -1.0));
+        assert_eq!(rect, Rect::new(-1.0, -1.0, 2.0, 2.0));
+
+        rect.push(Vector2::new(10.0, -1.0));
+        assert_eq!(rect, Rect::new(-1.0, -1.0, 11.0, 2.0));
+    }
+    #[test]
+    fn option_rect_extend_to_contain() {
+        let mut rect = OptionRect::default();
+
+        rect.extend_to_contain(Rect::new(1.0, 1.0, 1.0, 1.0));
+        assert_eq!(rect.unwrap(), Rect::new(1.0, 1.0, 1.0, 1.0));
+
+        rect.extend_to_contain(Rect::new(-1.0, -1.0, 1.0, 1.0));
+        assert_eq!(rect.unwrap(), Rect::new(-1.0, -1.0, 3.0, 3.0));
+
+        rect.extend_to_contain(Rect::new(10.0, -1.0, 1.0, 15.0));
+        assert_eq!(rect.unwrap(), Rect::new(-1.0, -1.0, 12.0, 15.0));
+    }
+    #[test]
+    fn option_rect_push() {
+        let mut rect = OptionRect::default();
+
+        rect.push(Vector2::new(1.0, 1.0));
+        assert_eq!(rect.unwrap(), Rect::new(1.0, 1.0, 0.0, 0.0));
+
+        rect.push(Vector2::new(-1.0, -1.0));
+        assert_eq!(rect.unwrap(), Rect::new(-1.0, -1.0, 2.0, 2.0));
+
+        rect.push(Vector2::new(10.0, -1.0));
+        assert_eq!(rect.unwrap(), Rect::new(-1.0, -1.0, 11.0, 2.0));
+    }
+    #[test]
+    fn option_rect_clip() {
+        let rect = OptionRect::<i32>::from(Rect::new(0, 0, 10, 10));
+
+        let mut r = rect;
+        r.clip(Rect::new(2, 2, 1, 1));
+        assert_eq!(r.unwrap(), Rect::new(2, 2, 1, 1));
+
+        let mut r = rect;
+        r.clip(Rect::new(0, 0, 15, 15));
+        assert_eq!(r.unwrap(), Rect::new(0, 0, 10, 10));
+
+        // When there is no intersection.
+        let mut r = OptionRect::default();
+        r.clip(Rect::new(0, 0, 10, 10));
+        assert!(r.is_none());
+        let mut r = rect;
+        r.clip(Rect::new(-2, 1, 1, 1));
+        assert!(r.is_none());
+        let mut r = rect;
+        r.clip(Rect::new(11, 1, 1, 1));
+        assert!(r.is_none());
+        let mut r = rect;
+        r.clip(Rect::new(1, -2, 1, 1));
+        assert!(r.is_none());
+        let mut r = rect;
+        r.clip(Rect::new(1, 11, 1, 1));
+        assert!(r.is_none());
+    }
+    #[test]
+    fn default_for_rect() {
+        assert_eq!(
+            Rect::<f32>::default(),
+            Rect {
+                position: Vector2::new(Zero::zero(), Zero::zero()),
+                size: Vector2::new(Zero::zero(), Zero::zero()),
+            }
+        );
+    }
+
+    #[test]
+    fn rect_with_position() {
+        let rect = Rect::new(0, 0, 1, 1);
+
+        assert_eq!(
+            rect.with_position(Vector2::new(1, 1)),
+            Rect::new(1, 1, 1, 1)
+        );
+    }
+
+    #[test]
+    fn rect_with_size() {
+        let rect = Rect::new(0, 0, 1, 1);
+
+        assert_eq!(
+            rect.with_size(Vector2::new(10, 10)),
+            Rect::new(0, 0, 10, 10)
+        );
+    }
+
+    #[test]
+    fn rect_inflate() {
+        let rect = Rect::new(0, 0, 1, 1);
+
+        assert_eq!(rect.inflate(5, 5), Rect::new(-5, -5, 11, 11));
+    }
+
+    #[test]
+    fn rect_deflate() {
+        let rect = Rect::new(-5, -5, 11, 11);
+
+        assert_eq!(rect.deflate(5, 5), Rect::new(0, 0, 1, 1));
+    }
+
+    #[test]
+    fn rect_contains() {
+        let rect = Rect::new(0, 0, 10, 10);
+
+        assert!(rect.contains(Vector2::new(0, 0)));
+        assert!(rect.contains(Vector2::new(0, 10)));
+        assert!(rect.contains(Vector2::new(10, 0)));
+        assert!(rect.contains(Vector2::new(10, 10)));
+        assert!(rect.contains(Vector2::new(5, 5)));
+
+        assert!(!rect.contains(Vector2::new(0, 20)));
+    }
+
+    #[test]
+    fn rect_center() {
+        let rect = Rect::new(0, 0, 10, 10);
+
+        assert_eq!(rect.center(), Vector2::new(5, 5));
+    }
+
+    #[test]
+    fn rect_push() {
+        let mut rect = Rect::new(10, 10, 11, 11);
+
+        rect.push(Vector2::new(0, 0));
+        assert_eq!(rect, Rect::new(0, 0, 21, 21));
+
+        rect.push(Vector2::new(0, 20));
+        assert_eq!(rect, Rect::new(0, 0, 21, 21));
+
+        rect.push(Vector2::new(20, 20));
+        assert_eq!(rect, Rect::new(0, 0, 21, 21));
+
+        rect.push(Vector2::new(30, 30));
+        assert_eq!(rect, Rect::new(0, 0, 30, 30));
+    }
+
+    #[test]
+    fn rect_getters() {
+        let rect = Rect::new(0, 0, 1, 1);
+
+        assert_eq!(rect.left_top_corner(), Vector2::new(0, 0));
+        assert_eq!(rect.left_bottom_corner(), Vector2::new(0, 1));
+        assert_eq!(rect.right_top_corner(), Vector2::new(1, 0));
+        assert_eq!(rect.right_bottom_corner(), Vector2::new(1, 1));
+
+        assert_eq!(rect.x(), 0);
+        assert_eq!(rect.y(), 0);
+        assert_eq!(rect.w(), 1);
+        assert_eq!(rect.h(), 1);
+    }
+
+    #[test]
+    fn rect_clip_by() {
+        let rect = Rect::new(0, 0, 10, 10);
+
+        assert_eq!(
+            rect.clip_by(Rect::new(2, 2, 1, 1)).unwrap(),
+            Rect::new(2, 2, 1, 1)
+        );
+        assert_eq!(
+            rect.clip_by(Rect::new(0, 0, 15, 15)).unwrap(),
+            Rect::new(0, 0, 10, 10)
+        );
+
+        // When there is no intersection.
+        assert!(rect.clip_by(Rect::new(-2, 1, 1, 1)).is_none());
+        assert!(rect.clip_by(Rect::new(11, 1, 1, 1)).is_none());
+        assert!(rect.clip_by(Rect::new(1, -2, 1, 1)).is_none());
+        assert!(rect.clip_by(Rect::new(1, 11, 1, 1)).is_none());
+    }
+
+    #[test]
+    fn rect_translate() {
+        let rect = Rect::new(0, 0, 10, 10);
+
+        assert_eq!(rect.translate(Vector2::new(5, 5)), Rect::new(5, 5, 10, 10));
+    }
+
+    #[test]
+    fn rect_intersects_circle() {
+        let rect = Rect::new(0.0, 0.0, 1.0, 1.0);
+
+        assert!(!rect.intersects_circle(Vector2::new(5.0, 5.0), 1.0));
+        assert!(rect.intersects_circle(Vector2::new(0.0, 0.0), 1.0));
+        assert!(rect.intersects_circle(Vector2::new(-0.5, -0.5), 1.0));
+    }
+
+    #[test]
+    fn rect_transform() {
+        let rect = Rect::new(0.0, 0.0, 1.0, 1.0);
+
+        assert_eq!(
+            rect.transform(&Matrix3::new(
+                1.0, 0.0, 0.0, //
+                0.0, 1.0, 0.0, //
+                0.0, 0.0, 1.0,
+            )),
+            rect,
+        );
+
+        assert_eq!(
+            rect.transform(&Matrix3::new(
+                2.0, 0.0, 0.0, //
+                0.0, 2.0, 0.0, //
+                0.0, 0.0, 2.0,
+            )),
+            Rect::new(0.0, 0.0, 2.0, 2.0),
+        );
     }
 }

--- a/src/quadtree.rs
+++ b/src/quadtree.rs
@@ -245,7 +245,7 @@ impl<I, const CAP: usize> QueryStorage for ArrayVec<I, CAP> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::math::Rect;
+    use crate::Rect;
 
     struct TestObject {
         bounds: Rect<f32>,


### PR DESCRIPTION
One of the advertised features of Rect is in creating 2D bounds based on a list of points, but the algorithm used to extend the Rect did not produce correct results and the value of the initial Rect was unintuitive. For this reason, I have:

* Changed the implementations of `push` and `extend_to_contain` so that they are simpler and more clearly correct.
* Created the `OptionRect` type that adds methods to `Option<Rect<T>>` to streamline the construction of bounding rects by using None as the initial value of the rect.
* Modified `clip_by` to return an `OptionRect`. The previous behaviour of `clip_by` can be replicated using `unwrap_or`, as in `rect.clip_by(bounds).unwrap_or(rect)`.
* Added extensive testing to confirm that everything is working as expected. Much of this is copied from fyrox-math, but it is good for a crate to come with its own tests.
* Changed the version from 0.1.0 to 0.2.0 to represent the fact that these modifications require some small changes in how this crate is used. The fyrox-math crate contains tests that will incorrectly fail and fyrox-ui needs to unwrap the results of `clip_by`.